### PR TITLE
fix: Add array fallback for inputChars variable

### DIFF
--- a/src/fondue/Fondue.js
+++ b/src/fondue/Fondue.js
@@ -878,7 +878,7 @@ export default class Fondue {
 				lookup.subtableOffsets.forEach((_, i) => {
 					const subtable = lookup.getSubTable(i);
 
-					let inputChars;
+					let inputChars = [];
 					let backtrackChars;
 					let lookaheadChars;
 


### PR DESCRIPTION
## Context
`inputChars.length > 0 cannot read properties of undefined (reading 'length')` error occurred when `subtable.inputGlyphCount > 0` evaluates to false

## Purpose
- Add fallback for inputChars and prevent error from being thrown when evaluating fondue.featureChars in the engine output.